### PR TITLE
Update Copyright Holder

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2014, eBay Software Foundation
+Copyright (c) 2014, PayPal
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -11,7 +11,7 @@ are permitted provided that the following conditions are met:
   list of conditions and the following disclaimer in the documentation and/or
   other materials provided with the distribution.
 
-* Neither the name of the eBay nor the names of its
+* Neither the name of the PayPal nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/README.md
+++ b/README.md
@@ -126,4 +126,4 @@ Please file a [Nemo a11y plugin issue][3]  for any nemo plugin related questions
 
 ## Copyright and License
 
-Copyright 2015, eBay Software Foundation under [the BSD license](LICENSE.md).
+Copyright 2015, PayPal under [the BSD license](LICENSE.md).


### PR DESCRIPTION
The license for this project still references the eBay Software Foundation. As part of the split earlier this year, copyright for this project was assigned from the eBay Software Foundation to PayPal.

Fixes #3 
